### PR TITLE
Fix issues found with go vet, fix gofmt.

### DIFF
--- a/cmd/hgo/cmdarchive.go
+++ b/cmd/hgo/cmdarchive.go
@@ -193,7 +193,7 @@ func (a *tarArchiver) symlink(name, target string, mTime time.Time) (err error) 
 }
 
 func (a *tarArchiver) initHeader(name string, mode int, mTime time.Time) (hdr *tar.Header) {
-	a.h = tar.Header{ /*Uname: "root", Gname: "root"*/}
+	a.h = tar.Header{ /*Uname: "root", Gname: "root"*/ }
 	hdr = &a.h
 	hdr.Name = name
 	hdr.ModTime = mTime

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -32,7 +32,7 @@ func createRepo(t testing.TB, commands []string) string {
 		cmd.Dir = dir
 		out, err := cmd.CombinedOutput()
 		if err != nil {
-			t.Fatalf("Command %q failed. Output was:\n\n%s", cmd, out)
+			t.Fatalf("Command %q failed. Output was:\n\n%s", command, out)
 		}
 	}
 

--- a/revlog/filebuilder.go
+++ b/revlog/filebuilder.go
@@ -174,8 +174,6 @@ func (p *FileBuilder) PreparePatch(r *Rec) (f *FilePatch, err error) {
 		}
 		r = r.Prev()
 	}
-	panic("not reached")
-
 }
 
 func scanMetaData(d []byte) (meta []byte) {


### PR DESCRIPTION
Wrong type `*os/exec.Cmd` was being used for printf verb `%q`. Print `command` instead of `cmd` as that's likely what was originally intended.

Remove unreachable code.

Fix gofmt formatting.
